### PR TITLE
Rename package from de.nielsfalk.playground.ktor.swagger

### DIFF
--- a/ktor-sample-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/sample/JsonApplication.kt
+++ b/ktor-sample-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/sample/JsonApplication.kt
@@ -1,9 +1,21 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger.sample
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
+import de.nielsfalk.ktor.swagger.Contact
+import de.nielsfalk.ktor.swagger.Group
+import de.nielsfalk.ktor.swagger.Information
+import de.nielsfalk.ktor.swagger.SwaggerSupport
+import de.nielsfalk.ktor.swagger.created
+import de.nielsfalk.ktor.swagger.delete
+import de.nielsfalk.ktor.swagger.get
+import de.nielsfalk.ktor.swagger.notFound
+import de.nielsfalk.ktor.swagger.ok
+import de.nielsfalk.ktor.swagger.post
+import de.nielsfalk.ktor.swagger.put
+import de.nielsfalk.ktor.swagger.responds
 import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.application.install
@@ -45,7 +57,12 @@ val rectangleSchemaMap = mapOf(
     )
 )
 
-val data = PetsModel(mutableListOf(PetModel(1, "max"), PetModel(2, "moritz")))
+val data = PetsModel(
+    mutableListOf(
+        PetModel(1, "max"),
+        PetModel(2, "moritz")
+    )
+)
 fun newId() = ((data.pets.map { it.id ?: 0 }.max()) ?: 0) + 1
 
 @Group("pet operations")
@@ -114,24 +131,38 @@ internal fun run(port: Int, wait: Boolean = true): ApplicationEngine {
                     data.pets.add(this)
                 })
             }
-            get<pet>("find".responds(ok<PetModel>(), notFound())) { params ->
+            get<pet>("find".responds(
+                ok<PetModel>(),
+                notFound()
+            )) { params ->
                 data.pets.find { it.id == params.id }
                     ?.let {
                         call.respond(it)
                     }
             }
-            put<pet, PetModel>("update".responds(ok<PetModel>(), notFound())) { params, entity ->
+            put<pet, PetModel>("update".responds(
+                ok<PetModel>(),
+                notFound()
+            )) { params, entity ->
                 if (data.pets.removeIf { it.id == params.id && it.id == entity.id }) {
                     data.pets.add(entity)
                     call.respond(entity)
                 }
             }
-            delete<pet>("delete".responds(ok<Unit>(), notFound())) { params ->
+            delete<pet>("delete".responds(
+                ok<Unit>(),
+                notFound()
+            )) { params ->
                 if (data.pets.removeIf { it.id == params.id }) {
                     call.respond(Unit)
                 }
             }
-            get<shapes>("all".responds(ok("Rectangle", rectangleSchemaMap))) {
+            get<shapes>("all".responds(
+                ok(
+                    "Rectangle",
+                    rectangleSchemaMap
+                )
+            )) {
                 call.respondText("""
                     {
                         "a" : 10,

--- a/ktor-sample-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/sample/ApplicationTest.kt
+++ b/ktor-sample-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/sample/ApplicationTest.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger.sample
 
 import org.junit.Test
 import java.util.concurrent.TimeUnit

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import io.ktor.application.ApplicationCall
 import io.ktor.application.call
@@ -34,8 +34,10 @@ data class Metadata(
 fun String.responds(vararg pairs: Pair<HttpStatusCode, ResponseType>): Metadata =
     Metadata(responses = mapOf(*pairs), summary = this)
 
-fun responds(pair: Pair<HttpStatusCode, ResponseType>) = Metadata(responses = mapOf(pair))
-fun responses(vararg pairs: Pair<HttpStatusCode, ResponseType>) = Metadata(responses = mapOf(*pairs))
+fun responds(pair: Pair<HttpStatusCode, ResponseType>) =
+    Metadata(responses = mapOf(pair))
+fun responses(vararg pairs: Pair<HttpStatusCode, ResponseType>) =
+    Metadata(responses = mapOf(*pairs))
 
 sealed class ResponseType
 
@@ -47,11 +49,20 @@ sealed class ReceiveType
 data class ReceiveFromReflection(val typeInfo: TypeInfo) : ReceiveType()
 data class ReceiveSchema(val name: ModelName, val schema: Any) : ReceiveType()
 
-inline fun <reified T> ok(): Pair<HttpStatusCode, ResponseType> = OK to ResponseFromReflection(typeInfo<T>())
+inline fun <reified T> ok(): Pair<HttpStatusCode, ResponseType> = OK to ResponseFromReflection(
+    typeInfo<T>()
+)
 fun ok(name: String, schema: Any) = OK to ResponseSchema(name, schema)
-inline fun <reified T> created(): Pair<HttpStatusCode, ResponseType> = Created to ResponseFromReflection(typeInfo<T>())
-fun created(name: String, schema: Any): Pair<HttpStatusCode, ResponseType> = Created to ResponseSchema(name, schema)
-inline fun notFound(): Pair<HttpStatusCode, ResponseType> = NotFound to ResponseFromReflection(typeInfo<Unit>())
+inline fun <reified T> created(): Pair<HttpStatusCode, ResponseType> = Created to ResponseFromReflection(
+    typeInfo<T>()
+)
+fun created(name: String, schema: Any): Pair<HttpStatusCode, ResponseType> = Created to ResponseSchema(
+    name,
+    schema
+)
+inline fun notFound(): Pair<HttpStatusCode, ResponseType> = NotFound to ResponseFromReflection(
+    typeInfo<Unit>()
+)
 
 @ContextDsl
 inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.post(
@@ -74,7 +85,9 @@ inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.post(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(LOCATION, ENTITY) -> Unit
 ): Route {
     application.swagger.apply {
-        metadata.apply<LOCATION, ENTITY>(HttpMethod.Post, ReceiveSchema(name = typeInfo<ENTITY>().modelName(), schema = entitySchema))
+        metadata.apply<LOCATION, ENTITY>(HttpMethod.Post,
+            ReceiveSchema(name = typeInfo<ENTITY>().modelName(), schema = entitySchema)
+        )
     }
     return post<LOCATION> {
         body(this, it, call.receive())
@@ -101,7 +114,9 @@ inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.put(
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(LOCATION, ENTITY) -> Unit
 ): Route {
     application.swagger.apply {
-        metadata.apply<LOCATION, ENTITY>(HttpMethod.Put, ReceiveSchema(name = typeInfo<ENTITY>().modelName(), schema = entitySchema))
+        metadata.apply<LOCATION, ENTITY>(HttpMethod.Put,
+            ReceiveSchema(name = typeInfo<ENTITY>().modelName(), schema = entitySchema)
+        )
     }
     return put<LOCATION> {
         body(this, it, call.receive())

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
@@ -1,9 +1,9 @@
 @file:Suppress("MemberVisibilityCanPrivate", "unused")
 
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
-import de.nielsfalk.playground.ktor.swagger.ParameterInputType.body
-import de.nielsfalk.playground.ktor.swagger.ParameterInputType.query
+import de.nielsfalk.ktor.swagger.ParameterInputType.body
+import de.nielsfalk.ktor.swagger.ParameterInputType.query
 import io.ktor.application.Application
 import io.ktor.application.ApplicationCall
 import io.ktor.application.feature
@@ -143,7 +143,9 @@ class Response(
         fun create(httpStatusCode: HttpStatusCode, typeInfo: TypeInfo): Response {
             return Response(
                 description = if (typeInfo.type == Unit::class) httpStatusCode.description else typeInfo.responseDescription(),
-                schema = if (typeInfo.type == Unit::class) null else ModelReference.create(typeInfo.modelName())
+                schema = if (typeInfo.type == Unit::class) null else ModelReference.create(
+                    typeInfo.modelName()
+                )
             )
         }
 
@@ -179,7 +181,7 @@ class Parameter(
 ) {
     companion object {
         fun create(
-            property: de.nielsfalk.playground.ktor.swagger.Property,
+            property: Property,
             name: String,
             `in`: ParameterInputType,
             description: String = property.description ?: name,
@@ -353,7 +355,10 @@ private fun KClass<*>.toModelProperty(
             }
         } else if (java.isEnum) {
             val enumConstants = (this).java.enumConstants
-            Property(enum = enumConstants.map { (it as Enum<*>).name }, type = "string") to emptyTypeInfoList
+            Property(
+                enum = enumConstants.map { (it as Enum<*>).name },
+                type = "string"
+            ) to emptyTypeInfoList
         } else {
             val typeInfo = when (reifiedType) {
                 is ParameterizedType -> TypeInfo(this, reifiedType)

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerParameterizedType.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerParameterizedType.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import io.ktor.application.Application
 import io.ktor.application.ApplicationCall
@@ -125,7 +125,15 @@ class SwaggerSupport(
                 }
             }
 
-            return Operation.create(this, responses, parameters, location, group, method, locationType)
+            return Operation.create(
+                this,
+                responses,
+                parameters,
+                location,
+                group,
+                method,
+                locationType
+            )
         }
 
         swagger.paths

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerUi.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerUi.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import io.ktor.application.ApplicationCall
 import io.ktor.content.OutgoingContent

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/TypeExtensions.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/TypeExtensions.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/getKType.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/getKType.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import com.winterbe.expekt.should
 import io.ktor.client.call.TypeInfo
@@ -78,11 +78,15 @@ class ModelExtractionTest {
 
     @Test
     fun `reference model property`() {
-        val modelWithDiscovered = createModelData(typeInfo<ModelProperty>())
+        val modelWithDiscovered =
+            createModelData(typeInfo<ModelProperty>())
         val property = modelWithDiscovered.first.properties["something"] as Property
 
         property.`$ref`.should.equal("#/definitions/PropertyModel")
-        assertEqualTypeInfo(typeInfo<PropertyModel>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<PropertyModel>(),
+            modelWithDiscovered.second.first()
+        )
     }
 
     class ModelStringArray(val something: List<String>)
@@ -110,7 +114,10 @@ class ModelExtractionTest {
         property.type.should.equal("array")
         property.items?.`$ref`.should.equal("#/definitions/SubModelElement")
 
-        assertEqualTypeInfo(typeInfo<SubModelElement>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<SubModelElement>(),
+            modelWithDiscovered.second.first()
+        )
     }
 
     class ModelWithGenericSet<T>(val something: Set<T>)
@@ -124,7 +131,10 @@ class ModelExtractionTest {
         property.type.should.equal("array")
         property.items?.`$ref`.should.equal("#/definitions/SubModelElement")
 
-        assertEqualTypeInfo(typeInfo<SubModelElement>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<SubModelElement>(),
+            modelWithDiscovered.second.first()
+        )
     }
 
     @Test
@@ -137,7 +147,10 @@ class ModelExtractionTest {
         property.type.should.equal("array")
         property.items?.`$ref`.should.equal("#/definitions/ModelWithGenericSetOfString")
 
-        assertEqualTypeInfo(typeInfo<ModelWithGenericSet<String>>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<ModelWithGenericSet<String>>(),
+            modelWithDiscovered.second.first()
+        )
     }
 
     class ModelNestedGenericList<T>(val somethingNested: List<List<T>>)
@@ -152,7 +165,10 @@ class ModelExtractionTest {
         property.items?.type.should.equal("array")
         property.items?.items?.`$ref`.should.equal("#/definitions/SubModelElement")
 
-        assertEqualTypeInfo(typeInfo<SubModelElement>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<SubModelElement>(),
+            modelWithDiscovered.second.first()
+        )
     }
 
     @Test
@@ -189,7 +205,10 @@ class ModelExtractionTest {
         property.items?.type.should.equal("array")
         property.items?.items?.`$ref`.should.equal("#/definitions/SubModelElement")
 
-        assertEqualTypeInfo(typeInfo<SubModelElement>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<SubModelElement>(),
+            modelWithDiscovered.second.first()
+        )
     }
 
     class GenericSubModel<S>(val value: S)
@@ -203,7 +222,10 @@ class ModelExtractionTest {
 
         val typeInfoForProperty = typeInfo<GenericSubModel<String>>()
 
-        assertEqualTypeInfo(typeInfoForProperty, property.returnTypeInfo(typeInfo.reifiedType))
+        assertEqualTypeInfo(
+            typeInfoForProperty,
+            property.returnTypeInfo(typeInfo.reifiedType)
+        )
     }
 
     @Test
@@ -213,7 +235,10 @@ class ModelExtractionTest {
         val property = GenericSubModel::class.memberProperties.first()
 
         val typeInfoForProperty = typeInfo<String>()
-        assertEqualTypeInfo(typeInfoForProperty, property.returnTypeInfo(typeInfo.reifiedType))
+        assertEqualTypeInfo(
+            typeInfoForProperty,
+            property.returnTypeInfo(typeInfo.reifiedType)
+        )
     }
 
     @Test
@@ -234,7 +259,10 @@ class ModelExtractionTest {
         val modelWithDiscovered =
             createModelData(typeInfo<ModelWithNestedGeneric<String>>())
 
-        assertEqualTypeInfo(typeInfo<GenericSubModel<String>>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<GenericSubModel<String>>(),
+            modelWithDiscovered.second.first()
+        )
 
         val property = modelWithDiscovered.first.properties["subModelElement"]!!
         property.`$ref`.should.equal("#/definitions/GenericSubModelOfString")
@@ -251,7 +279,10 @@ class ModelExtractionTest {
     fun `extract generic sub-model with two generics`() {
         val modelWithDiscovered =
             createModelData(typeInfo<ModelWithTwoNestedGeneric<String, Int>>())
-        assertEqualTypeInfo(typeInfo<GenericSubModelTwoGenerics<String, Int>>(), modelWithDiscovered.second.first())
+        assertEqualTypeInfo(
+            typeInfo<GenericSubModelTwoGenerics<String, Int>>(),
+            modelWithDiscovered.second.first()
+        )
         val property = modelWithDiscovered.first.properties["subModelElement"]!!
         property.`$ref`.should.equal("#/definitions/GenericSubModelTwoGenericsOfStringAndInt")
     }

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import com.winterbe.expekt.should
 import io.ktor.application.install
@@ -62,7 +62,12 @@ class SwaggerManualSchemaTest {
     @Test
     fun `custom ok return type`() {
         applicationCustomRoute {
-            get<rectangles>("all".responds(ok("Rectangle", rectangleSchemaMap))) { }
+            get<rectangles>("all".responds(
+                ok(
+                    "Rectangle",
+                    rectangleSchemaMap
+                )
+            )) { }
         }
         swagger.definitions["size"].should.equal(sizeSchemaMap)
         swagger.definitions["Rectangle"].should.equal(rectangleSchemaMap)
@@ -71,7 +76,10 @@ class SwaggerManualSchemaTest {
     @Test
     fun `custom put schema`() {
         applicationCustomRoute {
-            put<rectangles, Rectangle>(rectangleSchemaMap, "create".responds(created("Rectangles", rectanglesSchemaMap))) { _, _ ->
+            put<rectangles, Rectangle>(
+                rectangleSchemaMap, "create".responds(
+                    created("Rectangles", rectanglesSchemaMap)
+                )) { _, _ ->
             }
         }
         swagger.definitions["Rectangle"].should.equal(rectangleSchemaMap)

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupportTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupportTest.kt
@@ -1,4 +1,4 @@
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import com.winterbe.expekt.should
 import io.ktor.application.install

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
@@ -1,6 +1,6 @@
 @file:Suppress("UNCHECKED_CAST")
 
-package de.nielsfalk.playground.ktor.swagger
+package de.nielsfalk.ktor.swagger
 
 import com.winterbe.expekt.should
 import io.ktor.application.install
@@ -40,9 +40,15 @@ class SwaggerTest {
         }) {
             // when:
             application.routing {
-                put<toy, ToyModel>("update".responds(ok<ToyModel>(), notFound())) { _, _ -> }
+                put<toy, ToyModel>("update".responds(
+                    ok<ToyModel>(),
+                    notFound()
+                )) { _, _ -> }
                 post<toys, ToyModel>("create".responds(created<ToyModel>())) { _, _ -> }
-                get<toys>("all".responds(ok<ToysModel>(), notFound())) { }
+                get<toys>("all".responds(
+                    ok<ToysModel>(),
+                    notFound()
+                )) { }
                 get<withParameter>("with parameter".responds(ok<Unit>()).parameter<QueryParameter>().header<Header>()) {}
             }
 


### PR DESCRIPTION
Renamed `de.nielsfalk.playground.ktor.swagger` to`de.nielsfalk.ktor.swagger`.

Also, apparently IntelliJ decided to run some formatter as well which restructured some things.

This was the package name that @nielsfalk and I decided upon.