### PR TITLE
Add the body parameter to the Metadata instead of leaving it free floating

### DIFF
--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
@@ -21,22 +21,63 @@ import io.ktor.routing.application
 import kotlin.reflect.KClass
 
 data class Metadata(
-    val responses: Map<HttpStatusCode, ResponseType>,
-    val summary: String? = null,
-    val headers: KClass<*>? = null,
-    val parameter: KClass<*>? = null
+    internal val bodySchema: BodySchema? = null,
+    internal val responses: Map<HttpStatusCode, ResponseType> = emptyMap(),
+    internal val summary: String? = null,
+    internal val headers: KClass<*>? = null,
+    internal val parameter: KClass<*>? = null
 ) {
     inline fun <reified T> header(): Metadata = copy(headers = T::class)
 
     inline fun <reified T> parameter(): Metadata = copy(parameter = T::class)
 }
 
+fun Metadata.responds(vararg pairs: Pair<HttpStatusCode, ResponseType>): Metadata =
+    copy(
+        responses = (responses.entries + mapOf(*pairs).entries)
+            .map { it.key to it.value }
+            .toMap()
+    )
+
+/**
+ * Defines the schema for the body of the message of the incoming JSON object.
+ */
+data class BodySchema
+internal constructor(
+    internal val name: ModelName?,
+    internal val schema: Any
+)
+
+/**
+ * Define a custom schema for the body of the HTTP request.
+ * @param name The model name to use in the Swagger Schema.
+ * @receiver The summary to use for the operation.
+ */
+fun String.body(name: ModelName?, bodySchema: Any): Metadata =
+    Metadata(bodySchema = BodySchema(name, bodySchema), summary = this)
+
+fun body(name: ModelName?, bodySchema: Any): Metadata =
+    Metadata(bodySchema = BodySchema(name, bodySchema))
+
+/**
+ * Define a custom schema for the body of the HTTP request.
+ * The name will be infered from the reified `ENTITY` type.
+ * @receiver The summary to use for the operation.
+ */
+@JvmName("descriptionBody")
+fun String.body(bodySchema: Any) =
+    body(null, bodySchema)
+
+fun body(bodySchema: Any): Metadata =
+    body(null, bodySchema)
+
+/**
+ * @receiver The summary to use for the operation.
+ */
 fun String.responds(vararg pairs: Pair<HttpStatusCode, ResponseType>): Metadata =
     Metadata(responses = mapOf(*pairs), summary = this)
 
-fun responds(pair: Pair<HttpStatusCode, ResponseType>) =
-    Metadata(responses = mapOf(pair))
-fun responses(vararg pairs: Pair<HttpStatusCode, ResponseType>) =
+fun responds(vararg pairs: Pair<HttpStatusCode, ResponseType>) =
     Metadata(responses = mapOf(*pairs))
 
 sealed class ResponseType
@@ -44,22 +85,28 @@ sealed class ResponseType
 data class ResponseFromReflection(val type: TypeInfo) : ResponseType()
 data class ResponseSchema(val name: ModelName, val schema: Any) : ResponseType()
 
-sealed class ReceiveType
+/**
+ * The type of the operation body being recived by the server.
+ */
+sealed class BodyType
 
-data class ReceiveFromReflection(val typeInfo: TypeInfo) : ReceiveType()
-data class ReceiveSchema(val name: ModelName, val schema: Any) : ReceiveType()
+data class BodyFromReflection(val typeInfo: TypeInfo) : BodyType()
+data class BodyFromSchema(val name: ModelName, val schema: Any) : BodyType()
 
 inline fun <reified T> ok(): Pair<HttpStatusCode, ResponseType> = OK to ResponseFromReflection(
     typeInfo<T>()
 )
+
 fun ok(name: String, schema: Any) = OK to ResponseSchema(name, schema)
 inline fun <reified T> created(): Pair<HttpStatusCode, ResponseType> = Created to ResponseFromReflection(
     typeInfo<T>()
 )
+
 fun created(name: String, schema: Any): Pair<HttpStatusCode, ResponseType> = Created to ResponseSchema(
     name,
     schema
 )
+
 inline fun notFound(): Pair<HttpStatusCode, ResponseType> = NotFound to ResponseFromReflection(
     typeInfo<Unit>()
 )
@@ -79,44 +126,12 @@ inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.post(
 }
 
 @ContextDsl
-inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.post(
-    entitySchema: Any,
-    metadata: Metadata,
-    noinline body: suspend PipelineContext<Unit, ApplicationCall>.(LOCATION, ENTITY) -> Unit
-): Route {
-    application.swagger.apply {
-        metadata.apply<LOCATION, ENTITY>(HttpMethod.Post,
-            ReceiveSchema(name = typeInfo<ENTITY>().modelName(), schema = entitySchema)
-        )
-    }
-    return post<LOCATION> {
-        body(this, it, call.receive())
-    }
-}
-
-@ContextDsl
 inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.put(
     metadata: Metadata,
     noinline body: suspend PipelineContext<Unit, ApplicationCall>.(LOCATION, ENTITY) -> Unit
 ): Route {
     application.swagger.apply {
         metadata.apply<LOCATION, ENTITY>(HttpMethod.Put)
-    }
-    return put<LOCATION> {
-        body(this, it, call.receive())
-    }
-}
-
-@ContextDsl
-inline fun <reified LOCATION : Any, reified ENTITY : Any> Route.put(
-    entitySchema: Any,
-    metadata: Metadata,
-    noinline body: suspend PipelineContext<Unit, ApplicationCall>.(LOCATION, ENTITY) -> Unit
-): Route {
-    application.swagger.apply {
-        metadata.apply<LOCATION, ENTITY>(HttpMethod.Put,
-            ReceiveSchema(name = typeInfo<ENTITY>().modelName(), schema = entitySchema)
-        )
     }
     return put<LOCATION> {
         body(this, it, call.receive())

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
@@ -33,11 +33,7 @@ data class Metadata(
 }
 
 fun Metadata.responds(vararg pairs: Pair<HttpStatusCode, ResponseType>): Metadata =
-    copy(
-        responses = (responses.entries + mapOf(*pairs).entries)
-            .map { it.key to it.value }
-            .toMap()
-    )
+    copy(responses = (responses + mapOf(*pairs)))
 
 /**
  * Defines the schema for the body of the message of the incoming JSON object.

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
@@ -116,16 +116,16 @@ fun <T, R> KProperty1<T, R>.toParameter(
     }
 }
 
-internal fun ReceiveType.bodyParameter() =
+internal fun BodyType.bodyParameter() =
     when (this) {
-        is ReceiveFromReflection ->
+        is BodyFromReflection ->
             Parameter.create(
                 typeInfo.referenceProperty(),
                 name = "body",
                 description = typeInfo.modelName(),
                 `in` = body
             )
-        is ReceiveSchema ->
+        is BodyFromSchema ->
             Parameter.create(
                 referenceProperty(),
                 name = "body",
@@ -368,7 +368,7 @@ private fun KClass<*>.toModelProperty(
         }
 }
 
-private fun ReceiveSchema.referenceProperty(): Property =
+private fun BodyFromSchema.referenceProperty(): Property =
     Property(
         `$ref` = "#/definitions/" + name,
         description = name,

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
@@ -98,7 +98,7 @@ class SwaggerManualSchemaTest {
     }
 
     @Test
-    fun `custom schema name on the recive type`() {
+    fun `custom schema name on the receive type`() {
         val customName = "CustomName"
         applicationCustomRoute {
             post<rectangles, Rectangle>("create".body(customName, rectangleSchemaMap).responds(

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
@@ -62,12 +62,14 @@ class SwaggerManualSchemaTest {
     @Test
     fun `custom ok return type`() {
         applicationCustomRoute {
-            get<rectangles>("all".responds(
-                ok(
-                    "Rectangle",
-                    rectangleSchemaMap
+            get<rectangles>(
+                "all".responds(
+                    ok(
+                        "Rectangle",
+                        rectangleSchemaMap
+                    )
                 )
-            )) { }
+            ) { }
         }
         swagger.definitions["size"].should.equal(sizeSchemaMap)
         swagger.definitions["Rectangle"].should.equal(rectangleSchemaMap)
@@ -76,10 +78,10 @@ class SwaggerManualSchemaTest {
     @Test
     fun `custom put schema`() {
         applicationCustomRoute {
-            put<rectangles, Rectangle>(
-                rectangleSchemaMap, "create".responds(
+            put<rectangles, Rectangle>("create".body(rectangleSchemaMap).responds(
                     created("Rectangles", rectanglesSchemaMap)
-                )) { _, _ ->
+                )
+            ) { _, _ ->
             }
         }
         swagger.definitions["Rectangle"].should.equal(rectangleSchemaMap)
@@ -88,9 +90,37 @@ class SwaggerManualSchemaTest {
             should.not.be.`null`
         }?.also { operation ->
             operation.summary.should.equal("create")
-            operation.parameters.find { it.`in` == ParameterInputType.body }?.schema?.`$ref`.should.equal("#/definitions/Rectangle")
+            operation.parameters.find { it.`in` == ParameterInputType.body }
+                ?.schema?.`$ref`.should.equal("#/definitions/Rectangle")
             operation.responses.keys.should.contain("201")
             operation.responses["201"]?.schema?.`$ref`.should.equal("#/definitions/Rectangles")
+        }
+    }
+
+    @Test
+    fun `custom schema name on the recive type`() {
+        val customName = "CustomName"
+        applicationCustomRoute {
+            post<rectangles, Rectangle>("create".body(customName, rectangleSchemaMap).responds(
+                    created("Rectangles", rectanglesSchemaMap)
+                )
+            ) { _, _ ->
+            }
+        }
+        swagger.definitions[customName].should.equal(rectangleSchemaMap)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `body in get throws exception`() {
+        applicationCustomRoute {
+            get<rectangles>("Get All".body("")) {}
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `body in delete throws exception`() {
+        applicationCustomRoute {
+            delete<rectangles>("Delete All".body("")) {}
         }
     }
 }

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupportTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupportTest.kt
@@ -6,6 +6,9 @@ import io.ktor.features.ContentNegotiation
 import io.ktor.gson.GsonConverter
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import io.ktor.locations.Location
+import io.ktor.locations.Locations
+import io.ktor.routing.routing
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import org.junit.Test
@@ -17,9 +20,18 @@ class SwaggerSupportTest {
         application.install(SwaggerSupport) { forwardRoot = true }
 
         // then
-        handleRequest(HttpMethod.Get, "/").response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
-        handleRequest(HttpMethod.Get, "/apidocs").response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
-        handleRequest(HttpMethod.Get, "/apidocs/").response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
+        handleRequest(
+            HttpMethod.Get,
+            "/"
+        ).response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
+        handleRequest(
+            HttpMethod.Get,
+            "/apidocs"
+        ).response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
+        handleRequest(
+            HttpMethod.Get,
+            "/apidocs/"
+        ).response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
     }
 
     @Test
@@ -28,7 +40,10 @@ class SwaggerSupportTest {
         application.install(SwaggerSupport) { forwardRoot = true }
 
         // then
-        handleRequest(HttpMethod.Get, "/apidocs/index.html").response.content.should.contain("<title>Swagger UI</title>")
+        handleRequest(
+            HttpMethod.Get,
+            "/apidocs/index.html"
+        ).response.content.should.contain("<title>Swagger UI</title>")
     }
 
     @Test
@@ -45,5 +60,33 @@ class SwaggerSupportTest {
             method = HttpMethod.Get
             addHeader("Accept", ContentType.Application.Json.toString())
         }.response.content.should.contain("\"swagger\":\"2.0\"")
+    }
+
+    @Location("/model")
+    private class modelRoute
+
+    private class Model(val value: String)
+
+    @Test
+    fun `provide swaggerJson when a custom schema is provided`(): Unit = withTestApplication {
+        // when
+        application.install(ContentNegotiation) {
+            register(ContentType.Application.Json, GsonConverter())
+        }
+        application.install(SwaggerSupport) {
+            forwardRoot = true
+        }
+        application.install(Locations)
+
+        application.routing {
+            put<modelRoute, Model>(body(mapOf("type" to "object"))) { _, _ -> }
+        }
+
+        // then
+        handleRequest {
+            uri = "/apidocs/swagger.json"
+            method = HttpMethod.Get
+            addHeader("Accept", ContentType.Application.Json.toString())
+        }.response.content.should.contain("\"swagger\":\"2.0\"").and.contain("\"type\":\"object\"")
     }
 }


### PR DESCRIPTION
Refactors for defining routes that accept bodies this way:
```kotlin
put<rectangles, Rectangle>("create".body(rectangleSchemaMap).responds(created("Rectangles", rectanglesSchemaMap))) { _, _ ->
}
```

The body is now on the `Metadata` instead of on the method signature as an extra parameter.