### PR TITLE
Multiple content type response

### DIFF
--- a/ktor-swagger-root.gradle.kts
+++ b/ktor-swagger-root.gradle.kts
@@ -32,7 +32,7 @@ allprojects {
         plugin("com.diffplug.gradle.spotless")
     }
     group = "de.nielsfalk.ktor"
-    version = "0.2.1"
+    version = "0.2.2"
 
     repositories {
         mavenCentral()

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Annotations.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Annotations.kt
@@ -1,0 +1,11 @@
+package de.nielsfalk.ktor.swagger
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class DefaultValue(
+    val value: String
+)
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class Description(
+    val description: String
+)

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpStatusCode.Companion.BadRequest
 import io.ktor.http.HttpStatusCode.Companion.Created
+import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.http.HttpStatusCode.Companion.NotFound
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.locations.delete
@@ -30,12 +31,14 @@ data class Metadata(
     internal val responses: List<HttpCodeResponse> = emptyList(),
     internal val summary: String? = null,
     internal val description: String? = null,
-    internal val headers: KClass<*>? = null,
-    internal val parameter: KClass<*>? = null
+    @PublishedApi
+    internal val headers: List<KClass<*>> = emptyList(),
+    @PublishedApi
+    internal val parameters: List<KClass<*>> = emptyList()
 ) {
-    inline fun <reified T> header(): Metadata = copy(headers = T::class)
+    inline fun <reified T> header(): Metadata = copy(headers = headers + T::class)
 
-    inline fun <reified T> parameter(): Metadata = copy(parameter = T::class)
+    inline fun <reified T> parameter(): Metadata = copy(parameters = parameters + T::class)
 }
 
 data class HttpCodeResponse(
@@ -209,6 +212,15 @@ fun badRequest(name: String, vararg examples: Pair<String, Example> = arrayOf())
 
 fun badRequest(vararg responses: ResponseType = arrayOf(), description: String? = null): HttpCodeResponse =
     HttpCodeResponse(BadRequest, listOf(*responses), description)
+
+inline fun <reified T> internalServerError(vararg examples: Pair<String, Example> = arrayOf()): HttpCodeResponse =
+    internalServerError(json<T>(*examples))
+
+fun internalServerError(name: String, vararg examples: Pair<String, Example> = arrayOf()): HttpCodeResponse =
+    internalServerError(json(name, *examples))
+
+fun internalServerError(vararg responses: ResponseType = arrayOf(), description: String? = null): HttpCodeResponse =
+    HttpCodeResponse(InternalServerError, listOf(*responses), description)
 
 fun contentTypeResponse(contentType: ContentType): ResponseType =
     CustomContentTypeResponse(contentType)

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
@@ -33,17 +33,29 @@ import de.nielsfalk.ktor.swagger.version.v3.Response as ResponseV3
 
 class SwaggerSupport(
     val swagger: Swagger?,
-    val openApi: OpenApi?
+    val swaggerCustomization: Metadata.(HttpMethod) -> Metadata,
+    val openApi: OpenApi?,
+    val openApiCustomization: Metadata.(HttpMethod) -> Metadata
 ) {
     companion object Feature : ApplicationFeature<Application, SwaggerUiConfiguration, SwaggerSupport> {
         private val openApiJsonFileName = "openapi.json"
         private val swaggerJsonFileName = "swagger.json"
 
+        internal val swaggerVariation = SpecVariation("#/definitions/", ResponseV2, OperationV2, ParameterV2)
+        internal val openApiVariation = SpecVariation("#/components/schemas/", ResponseV3, OperationV3, ParameterV3)
+
         override val key = AttributeKey<SwaggerSupport>("SwaggerSupport")
 
         override fun install(pipeline: Application, configure: SwaggerUiConfiguration.() -> Unit): SwaggerSupport {
-            val (path, forwardRoot, provideUi, swagger, openApi) = SwaggerUiConfiguration().apply(configure)
-            val feature = SwaggerSupport(swagger, openApi)
+            val (path,
+                forwardRoot,
+                provideUi,
+                swagger,
+                openApi,
+                swaggerConfig,
+                openpapiConfig
+            ) = SwaggerUiConfiguration().apply(configure)
+            val feature = SwaggerSupport(swagger, swaggerConfig, openApi, openpapiConfig)
 
             val defaultJsonFile = when {
                 openApi != null -> openApiJsonFileName
@@ -88,57 +100,35 @@ class SwaggerSupport(
             when (it) {
                 is Swagger -> SwaggerBaseWithVariation(
                     it,
-                    SpecVariation("#/definitions/", ResponseV2, OperationV2, ParameterV2)
+                    swaggerCustomization,
+                    swaggerVariation
                 )
                 is OpenApi -> OpenApiBaseWithVariation(
                     it,
-                    SpecVariation("#/components/schemas/", ResponseV3, OperationV3, ParameterV3)
+                    openApiCustomization,
+                    openApiVariation
                 )
                 else -> throw IllegalStateException("Must be of type ${Swagger::class.simpleName} or ${OpenApi::class.simpleName}")
             }
         }
 
-    /**
-     * The [HttpMethod] types that don't support having a HTTP body element.
-     */
-    private val methodForbidsBody = setOf(HttpMethod.Get, HttpMethod.Delete)
-
     inline fun <reified LOCATION : Any, reified ENTITY_TYPE : Any> Metadata.apply(method: HttpMethod) {
         apply(LOCATION::class, typeInfo<ENTITY_TYPE>(), method)
     }
 
-    private fun Metadata.createBodyType(typeInfo: TypeInfo): BodyType =
-        bodySchema?.let {
-            BodyFromSchema(
-                name = bodySchema.name ?: typeInfo.modelName(),
-                examples = bodyExamples
-            )
-        } ?: BodyFromReflection(typeInfo, bodyExamples)
-
-    private fun Metadata.requireMethodSupportsBody(method: HttpMethod) =
-        require(!(methodForbidsBody.contains(method) && bodySchema != null)) {
-            "Method type $method does not support a body parameter."
-        }
-
-    fun Metadata.apply(locationClass: KClass<*>, bodyTypeInfo: TypeInfo, method: HttpMethod) {
-        requireMethodSupportsBody(method)
-        val bodyType = createBodyType(bodyTypeInfo)
-        val clazz = locationClass.java
-        val location = clazz.getAnnotation(Location::class.java)
-        val tags = clazz.getAnnotation(Group::class.java)
-
+    @PublishedApi
+    internal fun Metadata.apply(locationClass: KClass<*>, bodyTypeInfo: TypeInfo, method: HttpMethod) {
         variations.forEach {
-            it.apply {
-                applyOperations(location, tags, method, locationClass, bodyType)
-            }
+            it.apply { metaDataConfiguration(method).apply(locationClass, bodyTypeInfo, method) }
         }
     }
 }
 
 private class SwaggerBaseWithVariation(
     base: Swagger,
+    metaDataConfiguration: Metadata.(HttpMethod) -> Metadata,
     variation: SpecVariation
-) : BaseWithVariation<Swagger>(base, variation) {
+) : BaseWithVariation<Swagger>(base, metaDataConfiguration, variation) {
 
     override val schemaHolder: MutableMap<ModelName, Any>
         get() = base.definitions
@@ -150,8 +140,9 @@ private class SwaggerBaseWithVariation(
 
 private class OpenApiBaseWithVariation(
     base: OpenApi,
+    metaDataConfiguration: Metadata.(HttpMethod) -> Metadata,
     variation: SpecVariation
-) : BaseWithVariation<OpenApi>(base, variation) {
+) : BaseWithVariation<OpenApi>(base, metaDataConfiguration, variation) {
     override val schemaHolder: MutableMap<ModelName, Any>
         get() = base.components.schemas
 
@@ -162,6 +153,7 @@ private class OpenApiBaseWithVariation(
 
 private abstract class BaseWithVariation<B : CommonBase>(
     val base: B,
+    val metaDataConfiguration: Metadata.(HttpMethod) -> Metadata,
     val variation: SpecVariation
 ) {
     abstract val schemaHolder: MutableMap<ModelName, Any>
@@ -237,8 +229,8 @@ private abstract class BaseWithVariation<B : CommonBase>(
                             }
                         })
                     }
-                    parameter?.processToParameters(ParameterInputType.query)
-                    headers?.processToParameters(ParameterInputType.header)
+                    parameters.forEach { it.processToParameters(ParameterInputType.query) }
+                    headers.forEach { it.processToParameters(ParameterInputType.header) }
                 }
             }
 
@@ -271,6 +263,36 @@ private abstract class BaseWithVariation<B : CommonBase>(
         }
         return destination.toMap()
     }
+
+    private fun Metadata.createBodyType(typeInfo: TypeInfo): BodyType =
+        bodySchema?.let {
+            BodyFromSchema(
+                name = bodySchema.name ?: typeInfo.modelName(),
+                examples = bodyExamples
+            )
+        } ?: BodyFromReflection(typeInfo, bodyExamples)
+
+    private fun Metadata.requireMethodSupportsBody(method: HttpMethod) =
+        require(!(methodForbidsBody.contains(method) && bodySchema != null)) {
+            "Method type $method does not support a body parameter."
+        }
+
+    internal fun Metadata.apply(locationClass: KClass<*>, bodyTypeInfo: TypeInfo, method: HttpMethod) {
+        requireMethodSupportsBody(method)
+        val bodyType = createBodyType(bodyTypeInfo)
+        val clazz = locationClass.java
+        val location = clazz.getAnnotation(Location::class.java)
+        val tags = clazz.getAnnotation(Group::class.java)
+
+        applyOperations(location, tags, method, locationClass, bodyType)
+    }
+
+    companion object {
+        /**
+         * The [HttpMethod] types that don't support having a HTTP body element.
+         */
+        private val methodForbidsBody = setOf(HttpMethod.Get, HttpMethod.Delete)
+    }
 }
 
 data class SwaggerUiConfiguration(
@@ -278,5 +300,13 @@ data class SwaggerUiConfiguration(
     var forwardRoot: Boolean = false,
     var provideUi: Boolean = true,
     var swagger: Swagger? = null,
-    var openApi: OpenApi? = null
+    var openApi: OpenApi? = null,
+    /**
+     * Customization mutation applied to every [Metadata] processed for the swagger.json
+     */
+    var swaggerCustomization: Metadata.(HttpMethod) -> Metadata = { this },
+    /**
+     * Customization mutation applied to every [Metadata] processed for the openapi.json
+     */
+    var openApiCustomization: Metadata.(HttpMethod) -> Metadata = { this }
 )

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/shared/Shared.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/shared/Shared.kt
@@ -109,6 +109,7 @@ interface ParameterCreator {
         `in`: ParameterInputType,
         description: String? = property.description ?: name,
         required: Boolean = true,
+        default: String? = null,
         examples: Map<String, Example> = emptyMap()
     ): ParameterBase
 }
@@ -137,6 +138,7 @@ data class Property(
     val enum: List<String>? = null,
     val items: Property? = null,
     val description: String? = null,
+    val default: String? = null,
     override val `$ref`: String? = null
 ) : RefHolder
 

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/shared/Shared.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/shared/Shared.kt
@@ -1,11 +1,10 @@
 package de.nielsfalk.ktor.swagger.version.shared
 
+import de.nielsfalk.ktor.swagger.HttpCodeResponse
 import de.nielsfalk.ktor.swagger.Metadata
 import de.nielsfalk.ktor.swagger.toList
 import de.nielsfalk.ktor.swagger.version.v3.Example
-import io.ktor.client.call.TypeInfo
 import io.ktor.http.HttpMethod
-import io.ktor.http.HttpStatusCode
 import io.ktor.locations.Location
 
 typealias ModelName = String
@@ -78,9 +77,21 @@ interface OperationCreator {
     ): OperationBase
 }
 
-class ModelReference(val `$ref`: String) {
+class ModelOrModelReference
+internal constructor(
+    val `$ref`: String? = null,
+    val type: String? = null,
+    val format: String? = null
+) {
     companion object {
-        fun create(modelName: String) = ModelReference(modelName)
+        fun create(modelName: String) =
+            ModelOrModelReference(modelName)
+
+        fun create(type: String, format: String? = null) =
+            ModelOrModelReference(
+                type = type,
+                format = format
+            )
     }
 }
 
@@ -107,16 +118,7 @@ interface ResponseBase {
 }
 
 interface ResponseCreator {
-    fun create(
-        httpStatusCode: HttpStatusCode,
-        typeInfo: TypeInfo,
-        examples: Map<String, Example>
-    ): ResponseBase
-
-    fun create(
-        modelName: String,
-        examples: Map<String, Example>
-    ): ResponseBase
+    fun create(response: HttpCodeResponse): ResponseBase?
 }
 
 enum class ParameterInputType {

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v2/Schema.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v2/Schema.kt
@@ -128,6 +128,7 @@ class Parameter(
     val format: String? = null,
     val enum: List<String>? = null,
     val items: Property? = null,
+    val default: String? = null,
     val schema: ModelOrModelReference? = null
 ) : ParameterBase {
     companion object : ParameterCreator {
@@ -138,6 +139,7 @@ class Parameter(
             `in`: ParameterInputType,
             description: String?,
             required: Boolean,
+            default: String?,
             examples: Map<String, Example>
         ): Parameter {
             return Parameter(
@@ -149,6 +151,7 @@ class Parameter(
                 format = property.format,
                 enum = property.enum,
                 items = property.items,
+                default = default,
                 schema = property.`$ref`?.let { ModelOrModelReference(it) }
             )
         }

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v3/Schema.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v3/Schema.kt
@@ -266,6 +266,7 @@ class Parameter(
             `in`: ParameterInputType,
             description: String?,
             required: Boolean,
+            default: String?,
             examples: Map<String, Example>
         ): ParameterBase {
             return Parameter(
@@ -273,7 +274,7 @@ class Parameter(
                 `in` = `in`,
                 description = description,
                 required = required,
-                schema = property,
+                schema = property.copy(default = default),
                 examples = examples
             )
         }

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerManualSchemaTest.kt
@@ -1,7 +1,7 @@
 package de.nielsfalk.ktor.swagger
 
 import com.winterbe.expekt.should
-import de.nielsfalk.ktor.swagger.version.shared.ModelReference
+import de.nielsfalk.ktor.swagger.version.shared.ModelOrModelReference
 import de.nielsfalk.ktor.swagger.version.shared.ParameterInputType
 import de.nielsfalk.ktor.swagger.version.v2.Swagger
 import de.nielsfalk.ktor.swagger.version.v3.OpenApi
@@ -128,7 +128,7 @@ class SwaggerManualSchemaTest {
 
             operation.summary.should.equal("create")
             operation.responses.keys.should.contain("201")
-            ((operation.parameters.find { it.`in` == ParameterInputType.body } as ParameterV2).schema as ModelReference)
+            ((operation.parameters.find { it.`in` == ParameterInputType.body } as ParameterV2).schema as ModelOrModelReference)
                 .`$ref`.should.equal("#/definitions/Rectangle")
             (operation.responses["201"] as ResponseV2).schema?.`$ref`.should.equal("#/definitions/Rectangles")
         }

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
@@ -16,6 +16,7 @@ import io.ktor.routing.routing
 import io.ktor.server.testing.withTestApplication
 import org.junit.Before
 import org.junit.Test
+import de.nielsfalk.ktor.swagger.version.v2.Parameter as ParameterV2
 import de.nielsfalk.ktor.swagger.version.v2.Response as ResponseV2
 import de.nielsfalk.ktor.swagger.version.v3.Operation as OperationV3
 import de.nielsfalk.ktor.swagger.version.v3.Response as ResponseV3
@@ -44,6 +45,10 @@ data class ToysModel(val toys: MutableList<ToyModel>) {
     }
 }
 
+data class ErrorModel(
+    val message: String
+)
+
 const val toysLocation = "/toys/{id}"
 
 @Group("toy")
@@ -58,7 +63,12 @@ class toys
 @Location("/withParameter")
 class withParameter
 
-class Header(val optionalHeader: String?, val mandatoryHeader: Int)
+class Header(
+    val optionalHeader: String?,
+    val mandatoryHeader: Int,
+    @DefaultValue("false") val defaultHeader: Boolean = false
+)
+
 class QueryParameter(val optionalParameter: String?, val mandatoryParameter: Int)
 
 class SwaggerTest {
@@ -72,6 +82,16 @@ class SwaggerTest {
             install(SwaggerSupport) {
                 swagger = Swagger()
                 openApi = OpenApi()
+                openApiCustomization = {
+                    responds(
+                        internalServerError<ErrorModel>()
+                    )
+                }
+                swaggerCustomization = {
+                    responds(
+                        internalServerError<ErrorModel>()
+                    )
+                }
             }
         }) {
             // when:
@@ -107,15 +127,33 @@ class SwaggerTest {
                 get<toys>(
                     "all"
                         .responds(
-                        ok<ToysModel>(example("model", ToysModel.example)),
-                        notFound()
-                    )
+                            ok<ToysModel>(example("model", ToysModel.example)),
+                            notFound()
+                        )
                 ) { }
                 get<withParameter>("with parameter".responds(ok<Unit>()).parameter<QueryParameter>().header<Header>()) {}
             }
 
             this@SwaggerTest.swagger = application.swaggerUi.swagger!!
             this@SwaggerTest.openapi = application.swaggerUi.openApi!!
+        }
+    }
+
+    @Test
+    fun `swagger all paths have 500 response`() {
+        val responses = swagger.paths.flatMap { it.value.values }.mapNotNull { it.responses["500"] }
+        responses.should.be.size(5)
+        responses.map { it as ResponseV2 }.map { it.schema?.`$ref` }.forEach {
+            it.should.equal("#/definitions/ErrorModel")
+        }
+    }
+
+    @Test
+    fun `openapi all paths have 500 response`() {
+        val responses = openapi.paths.flatMap { it.value.values }.mapNotNull { it.responses["500"] }
+        responses.should.be.size(5)
+        responses.map { it as ResponseV3 }.map { it.content?.get("application/json")?.schema?.`$ref` }.forEach {
+            it.should.equal("#/components/schemas/ErrorModel")
         }
     }
 
@@ -244,5 +282,10 @@ class SwaggerTest {
         val mandatory = parameters?.find { it.name == "mandatoryHeader" }
         mandatory?.required.should.equal(true)
         mandatory?.`in`.should.equal(ParameterInputType.header)
+
+        val default = parameters?.find { it.name == "defaultHeader" }
+        default?.required.should.equal(false)
+        (default as ParameterV2).default.should.equal("false")
+        default?.`in`.should.equal(ParameterInputType.header)
     }
 }

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
@@ -9,6 +9,7 @@ import de.nielsfalk.ktor.swagger.version.shared.Property
 import de.nielsfalk.ktor.swagger.version.v2.Swagger
 import de.nielsfalk.ktor.swagger.version.v3.OpenApi
 import io.ktor.application.install
+import io.ktor.http.ContentType
 import io.ktor.locations.Location
 import io.ktor.locations.Locations
 import io.ktor.routing.routing
@@ -87,6 +88,18 @@ class SwaggerTest {
                             notFound()
                         )
                 ) { _, _ -> }
+                get<toy>(
+                    "image"
+                        .description("A single toy, also returns image of toy for correct mime type")
+                        .responds(
+                            ok(
+                                json<ToyModel>(),
+                                contentTypeResponse(ContentType.Image.PNG),
+                                description = ""
+                            )
+                        )
+                ) {
+                }
                 post<toys, ToyModel>(
                     "create"
                         .responds(created<ToyModel>())


### PR DESCRIPTION
You can now specify an endpoint that can respond with multiple content types:
```kotlin
get<toy>(
    "image"
        .description("A single toy, also returns image of toy for correct mime type")
        .responds(
            ok(
                json<ToyModel>(),
                contentTypeResponse(ContentType.Image.PNG),
                description = ""
            )
        )
)
```