### PR TITLE
Changes to support String as response type

### DIFF
--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
@@ -169,6 +169,7 @@ sealed class BodyType {
     abstract val examples: Map<String, Example>
 }
 
+data class BodyFromString(override val examples: Map<String, Example>): BodyType()
 data class BodyFromReflection(val typeInfo: TypeInfo, override val examples: Map<String, Example>) : BodyType()
 data class BodyFromSchema(val name: ModelName, override val examples: Map<String, Example>) : BodyType()
 

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Api.kt
@@ -169,7 +169,7 @@ sealed class BodyType {
     abstract val examples: Map<String, Example>
 }
 
-data class BodyFromString(override val examples: Map<String, Example>): BodyType()
+data class BodyFromString(override val examples: Map<String, Example>) : BodyType()
 data class BodyFromReflection(val typeInfo: TypeInfo, override val examples: Map<String, Example>) : BodyType()
 data class BodyFromSchema(val name: ModelName, override val examples: Map<String, Example>) : BodyType()
 

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
@@ -110,6 +110,13 @@ internal class SpecVariation(
                     `in` = body,
                     examples = examples
                 )
+            is BodyFromString ->
+                parameterCreator.create(
+                        Property("string"),
+                        name = "body",
+                        description = "body",
+                        `in` = body
+                )
         }
 
     fun <T, R> KProperty1<T, R>.toModelProperty(reifiedType: Type? = null): Pair<Property, Collection<TypeInfo>> =

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
@@ -194,6 +194,10 @@ private abstract class BaseWithVariation<B : CommonBase>(
                 if (typeInfo.type != Unit::class) {
                     addDefinition(typeInfo)
                 }
+                listOf("application/json")
+            }
+            is BodyFromString -> {
+                listOf("text/plain")
             }
         }
 
@@ -264,13 +268,16 @@ private abstract class BaseWithVariation<B : CommonBase>(
         return destination.toMap()
     }
 
-    private fun Metadata.createBodyType(typeInfo: TypeInfo): BodyType =
-        bodySchema?.let {
+    private fun Metadata.createBodyType(typeInfo: TypeInfo): BodyType = when {
+        bodySchema != null -> {
             BodyFromSchema(
-                name = bodySchema.name ?: typeInfo.modelName(),
-                examples = bodyExamples
+                    name = bodySchema.name ?: typeInfo.modelName(),
+                    examples = bodyExamples
             )
-        } ?: BodyFromReflection(typeInfo, bodyExamples)
+        }
+        typeInfo.type == String::class -> BodyFromString(bodyExamples)
+        else -> BodyFromReflection(typeInfo, bodyExamples)
+    }
 
     private fun Metadata.requireMethodSupportsBody(method: HttpMethod) =
         require(!(methodForbidsBody.contains(method) && bodySchema != null)) {

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
@@ -189,16 +189,8 @@ private abstract class BaseWithVariation<B : CommonBase>(
         bodyType: BodyType
     ) {
 
-        when (bodyType) {
-            is BodyFromReflection -> bodyType.typeInfo.let { typeInfo ->
-                if (typeInfo.type != Unit::class) {
-                    addDefinition(typeInfo)
-                }
-                listOf("application/json")
-            }
-            is BodyFromString -> {
-                listOf("text/plain")
-            }
+        if (bodyType is BodyFromReflection && bodyType.typeInfo.type != Unit::class) {
+            addDefinition(bodyType.typeInfo)
         }
 
         fun createOperation(): OperationBase {

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v2/Schema.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v2/Schema.kt
@@ -96,7 +96,9 @@ class Operation(
     override val parameters: List<ParameterBase>,
     override val tags: List<Tag>?,
     override val summary: String,
-    override val description: String?
+    override val description: String?,
+    val consumes: List<String>?
+
 ) : OperationBase {
 
     companion object : OperationCreator {
@@ -108,12 +110,18 @@ class Operation(
             description: String?,
             examples: Map<String, Example>
         ): OperationBase {
+            val consumes = parameters.filter { it.`in` == ParameterInputType.body }.firstOrNull()?.let {
+                if ((it as Parameter).type == "string") listOf("text/plain")
+                else listOf("application/json")
+            } ?: listOf()
+
             return Operation(
                 responses,
                 parameters,
                 tags,
                 summary,
-                description
+                description,
+                consumes
             )
         }
     }

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v3/Schema.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v3/Schema.kt
@@ -17,7 +17,6 @@ import de.nielsfalk.ktor.swagger.version.shared.ParameterCreator
 import de.nielsfalk.ktor.swagger.version.shared.ParameterInputType
 import de.nielsfalk.ktor.swagger.version.shared.Paths
 import de.nielsfalk.ktor.swagger.version.shared.Property
-import de.nielsfalk.ktor.swagger.version.shared.RefHolder
 import de.nielsfalk.ktor.swagger.version.shared.ResponseBase
 import de.nielsfalk.ktor.swagger.version.shared.ResponseCreator
 import de.nielsfalk.ktor.swagger.version.shared.Tag
@@ -222,7 +221,16 @@ class Operation(
 
             val requestBody: RequestBody? =
                 bodyParams.firstOrNull()?.let {
-                    val content = mapOf(
+                    val content = if (it.schema.type == "string") mapOf(
+                            "text/plain" to MediaTypeObject(
+                                    ModelOrModelReference(
+                                            type = "string"
+                                    ),
+                                    example = examples.values.firstOrNull()?.value,
+                                    examples = examples
+                            )
+                    )
+                    else mapOf(
                         "application/json" to MediaTypeObject(
                             ModelOrModelReference(
                                 `$ref` = it.schema.`$ref`!!
@@ -255,7 +263,7 @@ class Parameter(
     override val required: Boolean,
     val deprecated: Boolean = false,
     val allowEmptyValue: Boolean = true,
-    val schema: RefHolder,
+    val schema: Property,
     val example: Any? = null,
     val examples: Map<String, Example>? = null
 ) : ParameterBase {

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
@@ -18,6 +18,7 @@ import org.junit.Before
 import org.junit.Test
 import de.nielsfalk.ktor.swagger.version.v2.Parameter as ParameterV2
 import de.nielsfalk.ktor.swagger.version.v2.Response as ResponseV2
+import de.nielsfalk.ktor.swagger.version.v2.Operation as OperationV2
 import de.nielsfalk.ktor.swagger.version.v3.Operation as OperationV3
 import de.nielsfalk.ktor.swagger.version.v3.Response as ResponseV3
 
@@ -96,6 +97,14 @@ class SwaggerTest {
         }) {
             // when:
             application.routing {
+                post<toy, String>(
+                    "new"
+                        .description("Put a toy string!")
+                        .responds(
+                            ok<ToyModel>(),
+                            notFound()
+                        )
+                ) { _, _ -> }
                 put<toy, ToyModel>(
                     "update"
                         .description("Update a toy!")
@@ -142,7 +151,7 @@ class SwaggerTest {
     @Test
     fun `swagger all paths have 500 response`() {
         val responses = swagger.paths.flatMap { it.value.values }.mapNotNull { it.responses["500"] }
-        responses.should.be.size(5)
+        responses.should.be.size(6)
         responses.map { it as ResponseV2 }.map { it.schema?.`$ref` }.forEach {
             it.should.equal("#/definitions/ErrorModel")
         }
@@ -151,7 +160,7 @@ class SwaggerTest {
     @Test
     fun `openapi all paths have 500 response`() {
         val responses = openapi.paths.flatMap { it.value.values }.mapNotNull { it.responses["500"] }
-        responses.should.be.size(5)
+        responses.should.be.size(6)
         responses.map { it as ResponseV3 }.map { it.content?.get("application/json")?.schema?.`$ref` }.forEach {
             it.should.equal("#/components/schemas/ErrorModel")
         }
@@ -287,5 +296,15 @@ class SwaggerTest {
         default?.required.should.equal(false)
         (default as ParameterV2).default.should.equal("false")
         default?.`in`.should.equal(ParameterInputType.header)
+    }
+
+    @Test
+    fun `request type of String should create the correct bodyType for v2`() {
+        (swagger.paths[toysLocation]?.get("post") as OperationV2).consumes.should.equal(listOf("text/plain"))
+    }
+
+    @Test
+    fun `request type of String should create the correct bodyType for v3`() {
+        (openapi.paths[toysLocation]?.get("post") as OperationV3).requestBody?.content?.keys.should.equal(setOf("text/plain"))
     }
 }


### PR DESCRIPTION
This change supports the operation:
  put<location, String>(.....)

This allows the body of input to be a string and sets the content-type to text/plain

There are other ways to do this that are more generic and I can do that if you like but this gets the job done.