### PR TITLE
Applied JSON relative URL about:blank workaround. Fixes issue #27

### DIFF
--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupport.kt
@@ -88,7 +88,7 @@ class SwaggerSupport(
         }
 
         private suspend fun PipelineContext<Unit, ApplicationCall>.redirect(path: String, defaultJsonFile: String) {
-            call.respondRedirect("/$path/index.html?url=$defaultJsonFile")
+            call.respondRedirect("/$path/index.html?url=./$defaultJsonFile")
         }
     }
 

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupportTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerSupportTest.kt
@@ -27,15 +27,15 @@ class SwaggerSupportTest {
         handleRequest(
             HttpMethod.Get,
             "/"
-        ).response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
+        ).response.headers["Location"].should.equal("/apidocs/index.html?url=./swagger.json")
         handleRequest(
             HttpMethod.Get,
             "/apidocs"
-        ).response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
+        ).response.headers["Location"].should.equal("/apidocs/index.html?url=./swagger.json")
         handleRequest(
             HttpMethod.Get,
             "/apidocs/"
-        ).response.headers["Location"].should.equal("/apidocs/index.html?url=swagger.json")
+        ).response.headers["Location"].should.equal("/apidocs/index.html?url=./swagger.json")
     }
 
     @Test


### PR DESCRIPTION
See https://github.com/swagger-api/swagger-ui/issues/4107 for the underlying upstream Swagger UI issue.