### PR TITLE
Add Ignore annotation for class parameters

### DIFF
--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Annotations.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Annotations.kt
@@ -9,3 +9,6 @@ annotation class DefaultValue(
 annotation class Description(
     val description: String
 )
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class Ignore

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/Swagger.kt
@@ -33,6 +33,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.findAnnotation
 
 /**
  * Gets the [Application.swaggerUi] feature
@@ -218,7 +219,8 @@ internal class SpecVariation(
     fun createModelData(typeInfo: TypeInfo): ModelDataWithDiscoveredTypeInfo {
         val collectedClassesToRegister = mutableListOf<TypeInfo>()
         val modelProperties =
-            typeInfo.type.memberProperties.map {
+            typeInfo.type.memberProperties.mapNotNull {
+                if (it.findAnnotation<Ignore>() != null) return@mapNotNull null
                 val propertiesWithCollected = it.toModelProperty(typeInfo.reifiedType)
                 collectedClassesToRegister.addAll(propertiesWithCollected.second)
                 it.name to propertiesWithCollected.first

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
@@ -134,6 +134,18 @@ class ModelExtractionTest {
         )
     }
 
+    class ModelWithElementToIgnore(val returnMe: String, @Ignore val ignoreMe: String)
+
+    @Test
+    fun `model with property to ignore`() {
+        val model =
+                createModelData(typeInfo<ModelWithElementToIgnore>())
+        val returnedProperty = model.first.properties["returnMe"]!!
+
+        returnedProperty.type.should.equal("string")
+        model.first.properties["ignoreMe"].should.equal(null)
+    }
+
     class ModelWithGenericSet<T>(val something: Set<T>)
 
     @Test
@@ -307,7 +319,9 @@ class ModelExtractionTest {
         val mandatory: String,
         @DefaultValue("true")
         @Description(annotationDescription)
-        val default: Boolean = true
+        val default: Boolean = true,
+        @Ignore
+        val ignorable: String = "ignoreMe"
     )
 
     @Test

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
@@ -320,8 +320,6 @@ class ModelExtractionTest {
         @DefaultValue("true")
         @Description(annotationDescription)
         val default: Boolean = true,
-        @Ignore
-        val ignorable: String = "ignoreMe"
     )
 
     @Test

--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/ModelExtractionTest.kt
@@ -319,7 +319,7 @@ class ModelExtractionTest {
         val mandatory: String,
         @DefaultValue("true")
         @Description(annotationDescription)
-        val default: Boolean = true,
+        val default: Boolean = true
     )
 
     @Test


### PR DESCRIPTION
I would like to use my location classes to store additional descriptive data that can be referenced from the routing lambda function.  This additional data should not be part of the model.  To accomplish this, I've created an `Ignore` annotation which allows the class to have a property that is not included in the model.

Sample location:
```
@Group(ENDPOINT_GROUP)
@io.ktor.locations.KtorExperimentalLocationsAPI
@Location("/v1/sample")
class GetSample(@Description("UUID of sample to return") val uuid: String) {
    companion object: RouteMetadata {
        override val somethingThatAllRoutesCanDo = "Something"
    }
    @Ignore
    val companion = Companion
}
```
Sample route:
```
@io.ktor.locations.KtorExperimentalLocationsAPI
internal fun Routing.getSample() {
    get<GetSample>(metadata) { location ->
        location.companion.somethingThatAllRoutesCanDo
        // respond
    }
}
```

Resulting model for GetSample includes `uuid` but does not attempt to include `companion`.