### PR TITLE
Handle `Collection` return types on endpoints (#24)

### DIFF
--- a/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
+++ b/ktor-swagger/src/test/kotlin/de/nielsfalk/ktor/swagger/SwaggerTest.kt
@@ -294,7 +294,7 @@ class SwaggerTest {
 
     @Test
     fun `ToysModel with array properties`() {
-        val toys = (swagger.definitions.get("ToysModel") as? ModelData)?.properties?.get("toys") as Property
+        val toys = (swagger.definitions.get("ToysModel") as? ObjectModel)?.properties?.get("toys") as Property
 
         toys.type.should.equal("array")
         val items = toys.items as Property


### PR DESCRIPTION
Allows using generic `Collection`s as response types. 