### PR TITLE
Bump version and change download button to jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # [ktor](https://github.com/Kotlin/ktor) with [swaggerUi](https://swagger.io/)
 
 [![Build Status](https://travis-ci.com/nielsfalk/ktor-swagger.svg?branch=master)](https://travis-ci.com/nielsfalk/ktor-swagger)
-[![Download](https://api.bintray.com/packages/ktor-swagger/maven-artifacts/ktor-swagger/images/download.svg) ](https://bintray.com/ktor-swagger/maven-artifacts/ktor-swagger/_latestVersion)
+[![](https://jitpack.io/v/nielsfalk/ktor-swagger.svg)](https://jitpack.io/#nielsfalk/ktor-swagger)
+
 
 This project provides a library that allows you you to integrate the
  [swaggerUi](https://swagger.io/) with [ktor](https://github.com/Kotlin/ktor)

--- a/ktor-swagger-root.gradle.kts
+++ b/ktor-swagger-root.gradle.kts
@@ -32,7 +32,7 @@ allprojects {
         plugin("com.diffplug.gradle.spotless")
     }
     group = "de.nielsfalk.ktor"
-    version = "0.5.0"
+    version = "0.6.0"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Reason for change
=================
In order to simplify the release process for this project, it may be a good idea to switch from bintray to jitpack. Then, in order to release a new version, the following steps are required:
1. the version number must be bumped
2. a corresponding tag for the version must be created

Then jitpack automatically builds the release package and provides it as dependency. 

Additionally i bumped the version number to 0.6.0 as there are significant changes since the release of version 0.5.0. E.g. now it is supported to return collections without wrapper object. 


Disadvantages
==================
Jitpack does not use the correct groupId to reference the artifact. Thus, in build.gradle the project must be referenced as `implementation 'com.github.nielsfalk:ktor-swagger:0.5.0'` instead of `compile 'de.nielsfalk.ktor:ktor-swagger:0.5.0'`