### PR TITLE
Added securityDefinition to Swagger schema

### DIFF
--- a/ktor-sample-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/sample/JsonApplication.kt
+++ b/ktor-sample-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/sample/JsonApplication.kt
@@ -17,10 +17,12 @@ import de.nielsfalk.ktor.swagger.ok
 import de.nielsfalk.ktor.swagger.patch
 import de.nielsfalk.ktor.swagger.post
 import de.nielsfalk.ktor.swagger.put
+import de.nielsfalk.ktor.swagger.security
 import de.nielsfalk.ktor.swagger.responds
 import de.nielsfalk.ktor.swagger.version.shared.Contact
 import de.nielsfalk.ktor.swagger.version.shared.Group
 import de.nielsfalk.ktor.swagger.version.shared.Information
+import de.nielsfalk.ktor.swagger.version.v2.BasicAuthSecurityDefinition
 import de.nielsfalk.ktor.swagger.version.v2.Swagger
 import de.nielsfalk.ktor.swagger.version.v3.OpenApi
 import de.nielsfalk.ktor.swagger.version.v3.Schema
@@ -145,6 +147,8 @@ class QueryParameter(val optionalParameter: String?, val mandatoryParameter: Int
 internal fun run(port: Int, wait: Boolean = true): ApplicationEngine {
     println("Launching on port `$port`")
     val server = embeddedServer(Netty, port) {
+
+
         install(DefaultHeaders)
         install(Compression)
         install(CallLogging)
@@ -170,6 +174,7 @@ internal fun run(port: Int, wait: Boolean = true): ApplicationEngine {
                 definitions["size"] = sizeSchemaMap
                 definitions[petUuid] = petIdSchema
                 definitions["Rectangle"] = rectangleSchemaMap("#/definitions")
+                securityDefinitions.put("basic", BasicAuthSecurityDefinition())
             }
             openApi = OpenApi().apply {
                 info = information
@@ -177,7 +182,9 @@ internal fun run(port: Int, wait: Boolean = true): ApplicationEngine {
                 components.schemas[petUuid] = petIdSchema
                 components.schemas["Rectangle"] = rectangleSchemaMap("#/components/schemas")
             }
+
         }
+
         routing {
             get<pets>("all".responds(ok<PetsModel>(example("model", PetsModel.exampleModel)))) {
                 call.respond(data)
@@ -194,7 +201,7 @@ internal fun run(port: Int, wait: Boolean = true): ApplicationEngine {
                             example("rover", PetModel.exampleRover),
                             example("spike", PetModel.exampleSpike)
                         )
-                    )
+                    ).security(mapOf("basic" to listOf()))
             ) { _, entity ->
                 call.respond(Created, entity.copy(id = newId()).apply {
                     data.pets.add(this)
@@ -279,6 +286,8 @@ internal fun run(port: Int, wait: Boolean = true): ApplicationEngine {
                 respondRequestDetails()
             )
         }
+
+
     }
     return server.start(wait = wait)
 }

--- a/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v2/Schema.kt
+++ b/ktor-swagger/src/main/kotlin/de/nielsfalk/ktor/swagger/version/v2/Schema.kt
@@ -32,6 +32,20 @@ class Swagger : CommonBase {
     override var info: Information? = null
     override val paths: Paths = mutableMapOf()
     val definitions: Definitions = mutableMapOf()
+    val securityDefinitions: SecurityDefinitions = mutableMapOf()
+}
+
+abstract class SecurityDefinition(val type: SecurityDefinitionType)
+class BasicAuthSecurityDefinition() : SecurityDefinition(SecurityDefinitionType.basic)
+class ApiKeyAuthSecurityDefinition(val name: String, val `in`: String) : SecurityDefinition(SecurityDefinitionType.apiKey)
+class OAuth2SecurityDefinition(val flow: String, val authorizationUrl: String, val tokenUrl: String, val scopes: Map<String, String>) : SecurityDefinition(SecurityDefinitionType.oauth2)
+
+typealias SecurityDefinitions = MutableMap<String, SecurityDefinition>
+
+enum class SecurityDefinitionType {
+    basic,
+    apiKey,
+    oauth2
 }
 
 class Response(


### PR DESCRIPTION
Reason of change
================

The current implementation of swagger v2 schemas did not support security defintions to specify the authentication methods for different endpoints. However, the security annotation for each operation was already present. This pull request now allows it to specify the security defintion for swagger v2 schemas. 



Example
================

*Setup*
```
install(SwaggerSupport) {
    forwardRoot = true
    swagger = Swagger().apply {
        securityDefinitions.put("basic", BasicAuthSecurityDefinition())
    }
}
```

*Usage*
```
post<pets, PetModel>(
    "create"
        .description("Save a pet in our wonderful database!")
        .responds(
            created<PetModel>()
        ).security(mapOf("basic" to listOf()))
) { _, entity ->
    call.respond(Created, entity.copy(id = newId()).apply {
        data.pets.add(this)
    })
}
```

Limitations
================
1. I did not change the security defintion of generated openapi schemas. There, it was already possible to specify a security definition (using maps). Reworking this part may break existing implementations which rely on setting the securityDefinition via map. 

2. Specifying the authentication does not hook with the ktor authentication. It only provides an information for generating the correct schema. In order to actually enforce the authentication, ktors `authenticate(){/*...*/}` may be used. 
